### PR TITLE
增加捆绑歌词功能

### DIFF
--- a/playground/src/app.tsx
+++ b/playground/src/app.tsx
@@ -46,6 +46,10 @@ const App = () => {
   const onTrimEndChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     setTrimEnd(event.target.checked);
 
+  const [arrayLrcContent, setarrayLrcContent] = useState(DEFAULT_OPTIONS.trimEnd);
+  const onArrayLrcContent = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setarrayLrcContent(event.target.checked);
+
   return (
     <>
       <GlobalStyle />
@@ -77,6 +81,14 @@ const App = () => {
                 onChange={onTrimEndChange}
               />
             </label>
+            <label>
+              arrayLrcContent
+              <input
+                type="checkbox"
+                checked={arrayLrcContent}
+                onChange={onArrayLrcContent}
+              />
+            </label>
           </div>
           <Textarea value={lrc} onChange={onLrcChange} autoFocus />
         </div>
@@ -85,6 +97,7 @@ const App = () => {
           sortByStartTime={sortByStartTime}
           trimStart={trimStart}
           trimEnd={trimEnd}
+          arrayLrcContent={arrayLrcContent}
         />
       </Style>
       <Github />

--- a/playground/src/app.tsx
+++ b/playground/src/app.tsx
@@ -46,9 +46,9 @@ const App = () => {
   const onTrimEndChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     setTrimEnd(event.target.checked);
 
-  const [arrayLrcContent, setarrayLrcContent] = useState(DEFAULT_OPTIONS.trimEnd);
-  const onArrayLrcContent = (event: React.ChangeEvent<HTMLInputElement>) =>
-    setarrayLrcContent(event.target.checked);
+  const [combineSameTimeLrc, setCombineSameTimeLrc] = useState(DEFAULT_OPTIONS.combineSameTimeLrc);
+  const onCombineSameTimeLrc = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setCombineSameTimeLrc(event.target.checked);
 
   return (
     <>
@@ -82,11 +82,11 @@ const App = () => {
               />
             </label>
             <label>
-              arrayLrcContent
+              combineSameTimeLrc
               <input
                 type="checkbox"
-                checked={arrayLrcContent}
-                onChange={onArrayLrcContent}
+                checked={combineSameTimeLrc}
+                onChange={onCombineSameTimeLrc}
               />
             </label>
           </div>
@@ -97,7 +97,7 @@ const App = () => {
           sortByStartTime={sortByStartTime}
           trimStart={trimStart}
           trimEnd={trimEnd}
-          arrayLrcContent={arrayLrcContent}
+          combineSameTimeLrc={combineSameTimeLrc}
         />
       </Style>
       <Github />

--- a/playground/src/json_view.tsx
+++ b/playground/src/json_view.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import JsonView from 'react-json-view';
-import { parse } from 'clrc';
+import { parse } from '../../src';
 
 const Style = styled.div`
   overflow: auto;
@@ -15,23 +15,23 @@ const Wrapper = ({
   sortByStartTime,
   trimStart,
   trimEnd,
-  arrayLrcContent
+  combineSameTimeLrc
 }: {
   lrc: string;
   sortByStartTime: boolean;
   trimStart: boolean;
   trimEnd: boolean;
-  arrayLrcContent: boolean;
+  combineSameTimeLrc?: boolean;
 }) => {
   const [lrcObject, setLrcObject] = useState(parse(lrc));
 
   useEffect(() => {
     const timer = window.setTimeout(
-      () => setLrcObject(parse(lrc, { sortByStartTime, trimStart, trimEnd, arrayLrcContent })),
+      () => setLrcObject(parse(lrc, { sortByStartTime, trimStart, trimEnd, combineSameTimeLrc })),
       300
     );
     return () => window.clearTimeout(timer);
-  }, [lrc, sortByStartTime, trimStart, trimEnd, arrayLrcContent]);
+  }, [lrc, sortByStartTime, trimStart, trimEnd, combineSameTimeLrc]);
 
   useEffect(() => {
     console.log(lrcObject);

--- a/playground/src/json_view.tsx
+++ b/playground/src/json_view.tsx
@@ -15,21 +15,23 @@ const Wrapper = ({
   sortByStartTime,
   trimStart,
   trimEnd,
+  arrayLrcContent
 }: {
   lrc: string;
   sortByStartTime: boolean;
   trimStart: boolean;
   trimEnd: boolean;
+  arrayLrcContent: boolean;
 }) => {
   const [lrcObject, setLrcObject] = useState(parse(lrc));
 
   useEffect(() => {
     const timer = window.setTimeout(
-      () => setLrcObject(parse(lrc, { sortByStartTime, trimStart, trimEnd })),
+      () => setLrcObject(parse(lrc, { sortByStartTime, trimStart, trimEnd, arrayLrcContent })),
       300
     );
     return () => window.clearTimeout(timer);
-  }, [lrc, sortByStartTime, trimStart, trimEnd]);
+  }, [lrc, sortByStartTime, trimStart, trimEnd, arrayLrcContent]);
 
   useEffect(() => {
     console.log(lrcObject);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,11 @@ export interface LyricLine extends LrcLine {
   content: string;
 }
 
+export interface LyricLineWithSecondLrc extends LrcLine {
+  startMillisecond: number;
+  content: string[];
+}
+
 export type ParseOptions = {
   /** whether to sort lyrics by start time */
   sortByStartTime?: boolean;
@@ -20,10 +25,13 @@ export type ParseOptions = {
   trimStart?: boolean;
   /** whether to remove end spaces */
   trimEnd?: boolean;
+  /** change lrc content from `string` to `string[]` */
+  arrayLrcContent?: boolean;
 };
 
 export const DEFAULT_OPTIONS: ParseOptions = {
   sortByStartTime: false,
   trimStart: true,
   trimEnd: false,
+  arrayLrcContent: false,
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,13 +25,13 @@ export type ParseOptions = {
   trimStart?: boolean;
   /** whether to remove end spaces */
   trimEnd?: boolean;
-  /** change lrc content from `string` to `string[]` */
-  arrayLrcContent?: boolean;
+  /** combine same time lrc, this will change content to array and open `sortByStartTime` options */
+  combineSameTimeLrc?: boolean;
 };
 
 export const DEFAULT_OPTIONS: ParseOptions = {
   sortByStartTime: false,
   trimStart: true,
   trimEnd: false,
-  arrayLrcContent: false,
+  combineSameTimeLrc: false,
 };

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -4,6 +4,7 @@ import {
   LyricLine,
   ParseOptions,
   DEFAULT_OPTIONS,
+  LyricLineWithSecondLrc,
 } from './constants';
 
 /**
@@ -27,6 +28,7 @@ function parse<MetadataKey extends string>(
     sortByStartTime = DEFAULT_OPTIONS.sortByStartTime,
     trimStart = DEFAULT_OPTIONS.trimStart,
     trimEnd = DEFAULT_OPTIONS.trimEnd,
+    arrayLrcContent = DEFAULT_OPTIONS.arrayLrcContent,
   }: ParseOptions = {}
 ) {
   const metadatas: MetadataLine<MetadataKey>[] = [];
@@ -36,6 +38,7 @@ function parse<MetadataKey extends string>(
   } = {};
 
   let lyrics: LyricLine[] = [];
+  const arrayContentLyrics: LyricLineWithSecondLrc[] = [];
   const invalidLines: LrcLine[] = [];
 
   const lines = lrc.split('\n');
@@ -62,11 +65,19 @@ function parse<MetadataKey extends string>(
         const centisecond = timeMatch[3] || '00'; // compatible with [00:00]
         const centisecondNumber =
           centisecond.length === 3 ? +centisecond : +centisecond * 10; // // compatible with [00:00.000]
+
         lyrics.push({
           lineNumber: i,
           startMillisecond:
             +minute * 60 * 1000 + +second * 1000 + centisecondNumber,
           content: lyricMatch[2],
+          raw,
+        });
+        arrayContentLyrics.push({
+          lineNumber: i,
+          startMillisecond:
+            +minute * 60 * 1000 + +second * 1000 + centisecondNumber,
+          content: [lyricMatch[2]],
           raw,
         });
       }
@@ -106,7 +117,7 @@ function parse<MetadataKey extends string>(
     metadatas,
     metadata,
 
-    lyrics,
+    lyrics: arrayLrcContent ? arrayContentLyrics : lyrics,
     invalidLines,
   };
 }


### PR DESCRIPTION
可以将相同时间的歌词捆绑成数组，这个功能启用的同时 sortByTime 也会一起启用，默认关闭

![Snipaste_2022-08-27_16-30-07](https://user-images.githubusercontent.com/86217807/187022202-ef4ec278-8439-4b4f-8da9-1fb87c7cbdd6.jpg)
